### PR TITLE
Enhanced UI and display database data pull details

### DIFF
--- a/lib/phoenix_profiler/elements/ecto_repo_usage.ex
+++ b/lib/phoenix_profiler/elements/ecto_repo_usage.ex
@@ -16,6 +16,8 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
           <.label>in</.label>
           {@duration.value}
           <.label>{@duration.label}</.label>
+          <.label>•</.label>
+          {@total_data_size}
 
           <span :if={@possible_n_plus_one == true}>Possible N+1 issue</span>
         </a>
@@ -33,25 +35,56 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
           <:label>Total time</:label>
           <:value>{@duration.value} {@duration.label}</:value>
         </.item>
+        <.item>
+          <:label>Data loaded</:label>
+          <:value>{@total_data_size}</:value>
+        </.item>
       </:details>
     </.element>
-    <dialog id="phxprof--stacktrace" style="width: 1000px; min-height: 350px;" class="code-analysis">
-      <h1>Queries duration and execution counts - {@count}</h1>
-      <hr /> Queries & stacktrace <hr />
-      <div id="query_list">
+    <dialog id="phxprof--stacktrace" class="phxprof-dialog">
+      <div class="phxprof-dialog-header">
+        <h2 class="phxprof-dialog-title">Database Queries</h2>
+        <span class="phxprof-dialog-meta">
+          {@count} total &middot; {@unique_queries_count} unique &middot; {@total_data_size} loaded
+        </span>
+        <button class="phxprof-dialog-close" id="close-dialog" aria-label="Close">&times;</button>
+      </div>
+      <div class="phxprof-query-table-header">
+        <span>Source</span>
+        <span>Query</span>
+        <span>Exec.</span>
+        <span>Time</span>
+        <span>Data</span>
+      </div>
+      <div id="query_list" class="phxprof-query-list">
         <%= for query <- @queries do %>
-          <details>
-            <summary>
-              <strong>{query.source}</strong>
-              : {String.slice(query.query, 0..50)}... - Executed {query.execution_count} times - Total time: {query.total_time.value} {query.total_time.label}
+          <details class="phxprof-query-row">
+            <summary class="phxprof-query-summary">
+              <span class="phxprof-query-source">{query.source}</span>
+              <span class="phxprof-query-sql">
+                <span :if={query.possible_n_plus_one} class="phxprof-n-plus-one-badge">N+1</span>
+                {String.slice(query.query, 0..100)}
+              </span>
+              <span class="phxprof-query-count">{query.execution_count}&times;</span>
+              <span class="phxprof-query-time">
+                {query.total_time.value} {query.total_time.label}
+              </span>
+              <span class="phxprof-query-data">{query.formatted_data_size}</span>
             </summary>
-            <strong>Query</strong> <br />
-            {query.query}
-            <br />
-            <strong>Stacktrace</strong> <br />
-            <%= for stack_entry <- clean_stacktrace(query.stacktrace) do %>
-              {Exception.format_stacktrace_entry(stack_entry)} <br />
-            <% end %>
+            <div class="phxprof-query-detail">
+              <div>
+                <span class="phxprof-query-detail-label">Full Query</span>
+                <code class="phxprof-query-code">{query.query}</code>
+              </div>
+              <details class="phxprof-stacktrace-toggle">
+                <summary class="phxprof-stacktrace-summary">Stacktrace</summary>
+                <div class="phxprof-query-stacktrace">
+                  <%= for stack_entry <- clean_stacktrace(query.stacktrace) do %>
+                    <span>{Exception.format_stacktrace_entry(stack_entry)}</span>
+                  <% end %>
+                </div>
+              </details>
+            </div>
           </details>
         <% end %>
       </div>
@@ -92,19 +125,29 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
       query: metadata.query,
       source: metadata.source,
       repo: metadata.repo,
-      stacktrace: metadata.stacktrace
+      stacktrace: metadata.stacktrace,
+      data_size: measure_result_size(metadata[:result])
     }
   end
+
+  defp measure_result_size({:ok, result}) do
+    word_size = :erlang.system_info(:wordsize)
+    :erts_debug.flat_size(result) * word_size
+  end
+
+  defp measure_result_size(_), do: 0
 
   @impl PhoenixProfiler.Element
   def entries_assigns(entries) do
     total_duration = entries |> Stream.map(& &1.measurements.total_time) |> Enum.sum()
+    total_data_size = entries |> Enum.sum_by(& &1.data_size)
     aggregated_queries = aggregate_data_for_unique_queries(entries)
 
     %{
       count: length(entries),
       unique_queries_count: length(aggregated_queries),
       duration: formatted_duration(total_duration),
+      total_data_size: format_bytes(total_data_size),
       queries: aggregated_queries,
       possible_n_plus_one: possible_n_plus_one?(Enum.at(aggregated_queries, 0))
     }
@@ -136,9 +179,16 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
 
       total_time = Enum.sum_by(filtered_entries, & &1.measurements.total_time)
 
+      total_data_size = Enum.sum_by(filtered_entries, & &1.data_size)
+
+      execution_count = length(filtered_entries)
+
       Map.merge(unique_entry, %{
         total_time: formatted_duration(total_time),
-        execution_count: length(filtered_entries)
+        execution_count: execution_count,
+        total_data_size: total_data_size,
+        formatted_data_size: format_bytes(total_data_size),
+        possible_n_plus_one: execution_count > @n_plus_one_repetition_threshold
       })
     end)
     |> Enum.sort_by(& &1.execution_count, :desc)
@@ -165,6 +215,14 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
       Enum.at(String.split(Atom.to_string(module), "."), 1) not in filter_on_modules
     end)
   end
+
+  defp format_bytes(bytes) when bytes < 1_000, do: "#{bytes} bytes"
+  defp format_bytes(bytes) when bytes < 1_000_000, do: "#{Float.round(bytes / 1_000, 1)} KB"
+
+  defp format_bytes(bytes) when bytes < 1_000_000_000,
+    do: "#{Float.round(bytes / 1_000_000, 1)} MB"
+
+  defp format_bytes(bytes), do: "#{Float.round(bytes / 1_000_000_000, 1)} GB"
 
   defp formatted_duration(nil), do: nil
 

--- a/lib/phoenix_profiler/toolbar_live.ex
+++ b/lib/phoenix_profiler/toolbar_live.ex
@@ -8,10 +8,12 @@ defmodule PhoenixProfiler.ToolbarLive do
 
   require Logger
 
-  @toolbar_css Application.app_dir(:phoenix_profiler, "priv/static/toolbar.css")
-               |> File.read!()
-  @toolbar_js Application.app_dir(:phoenix_profiler, "priv/static/toolbar.js")
-              |> File.read!()
+  @toolbar_css_path Application.app_dir(:phoenix_profiler, "priv/static/toolbar.css")
+  @toolbar_js_path Application.app_dir(:phoenix_profiler, "priv/static/toolbar.js")
+  @external_resource @toolbar_css_path
+  @external_resource @toolbar_js_path
+  @toolbar_css File.read!(@toolbar_css_path)
+  @toolbar_js File.read!(@toolbar_js_path)
 
   def toolbar(assigns) do
     assigns =

--- a/priv/static/toolbar.css
+++ b/priv/static/toolbar.css
@@ -185,3 +185,232 @@
     display: none !important;
   }
 }
+
+/* ─── Query dialog ─────────────────────────────────────────────── */
+
+/* Shared column layout – MUST be identical on header and summary rows */
+.phxprof-query-table-header,
+.phxprof-query-summary {
+  display: grid;
+  grid-template-columns: 7rem 1fr 4rem 5.5rem 5.5rem;
+  align-items: center;
+  gap: 0 1rem;
+  padding: 0.5rem 1rem;
+}
+
+.phxprof-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+  width: min(1100px, 96vw);
+  min-height: 350px;
+  max-height: 80vh;
+  padding: 0;
+  border: 1px solid var(--color-stroke);
+  border-radius: 0.375rem;
+  background-color: var(--color-canvas-default);
+  color: var(--color-fg-default);
+  font-size: 0.875rem;
+  overflow: hidden;
+}
+
+.phxprof-dialog[open] {
+  display: flex;
+  flex-direction: column;
+}
+
+.phxprof-dialog-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-stroke);
+  background-color: var(--color-canvas-secondary);
+  flex-shrink: 0;
+}
+
+.phxprof-dialog-close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--color-fg-secondary);
+  padding: 0 0.25rem;
+}
+
+.phxprof-dialog-close:hover {
+  color: var(--color-fg-default);
+}
+
+.phxprof-dialog-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-fg-default);
+}
+
+.phxprof-dialog-meta {
+  color: var(--color-fg-secondary);
+  font-size: 0.8rem;
+}
+
+.phxprof-query-table-header {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-fg-secondary);
+  background-color: var(--color-canvas-secondary);
+  border-bottom: 2px solid var(--color-stroke);
+  flex-shrink: 0;
+}
+
+.phxprof-query-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.phxprof-query-row {
+  border-bottom: 1px solid var(--color-stroke);
+}
+
+.phxprof-query-row:last-child {
+  border-bottom: none;
+}
+
+/* summary acts as the table row */
+.phxprof-query-summary {
+  list-style: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.phxprof-query-summary::-webkit-details-marker {
+  display: none;
+}
+
+.phxprof-query-summary:hover {
+  background-color: var(--color-canvas-secondary);
+}
+
+.phxprof-query-source {
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--color-link);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.phxprof-query-sql {
+  font-family: monospace;
+  font-size: 0.78rem;
+  color: var(--color-fg-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.phxprof-n-plus-one-badge {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.1rem 0.35rem;
+  font-family: sans-serif;
+  font-size: 0.65rem;
+  font-weight: bold;
+  color: #fff;
+  background-color: #e05252;
+  border-radius: 3px;
+  vertical-align: middle;
+  letter-spacing: 0.03em;
+}
+
+.phxprof-query-count,
+.phxprof-query-time,
+.phxprof-query-data {
+  text-align: right;
+  font-size: 0.82rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* ─── Expanded detail panel ────────────────────────────────────── */
+
+.phxprof-query-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem 0.75rem 1.5rem;
+  background-color: var(--color-canvas-secondary);
+  border-top: 1px solid var(--color-stroke);
+}
+
+.phxprof-query-detail-label {
+  display: block;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-fg-secondary);
+  margin-bottom: 0.2rem;
+}
+
+.phxprof-query-code {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-canvas-default);
+  border: 1px solid var(--color-stroke);
+  border-radius: 0.25rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: var(--color-fg-default);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ─── Stacktrace nested toggle ─────────────────────────────────── */
+
+.phxprof-stacktrace-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  list-style: none;
+  margin-bottom: 0.2rem;
+}
+
+.phxprof-stacktrace-summary::-webkit-details-marker {
+  display: none;
+}
+
+.phxprof-stacktrace-summary::after {
+  content: '▶';
+  font-size: 0.55rem;
+  transition: transform 0.15s ease;
+}
+
+.phxprof-stacktrace-toggle[open] > .phxprof-stacktrace-summary::after {
+  transform: rotate(90deg);
+}
+
+.phxprof-query-stacktrace {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-canvas-default);
+  border: 1px solid var(--color-stroke);
+  border-radius: 0.25rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: var(--color-fg-secondary);
+}

--- a/priv/static/toolbar.js
+++ b/priv/static/toolbar.js
@@ -18,6 +18,11 @@ toolbar
   .querySelector(".hide-button")
   .addEventListener("click", () => toggleToolbar(false));
 document.getElementById("show-dialog").addEventListener("click", () => toggleStackDialog());
+const stacktraceDialog = document.getElementById("phxprof--stacktrace");
+document.getElementById("close-dialog").addEventListener("click", () => stacktraceDialog.close());
+stacktraceDialog.addEventListener("click", (e) => {
+  if (e.target === stacktraceDialog) stacktraceDialog.close();
+});
 
 toggleToolbar(localStorage.getItem(SHOW) === "true");
 


### PR DESCRIPTION
## Description

### Details

This feature introduces an enhanced user interface that provides detailed insights into database queries. It displays the amount of data pulled from the database, along with execution counts, total query time, and potential N+1 issues. 

<img width="881" height="468" alt="image" src="https://github.com/user-attachments/assets/41eaf3c3-087b-4d8e-bdab-caa44e34239f" />

<img width="881" height="468" alt="image" src="https://github.com/user-attachments/assets/ecef9a09-feda-4597-94ba-3b84ef04bf07" />
<img width="630" height="77" alt="image" src="https://github.com/user-attachments/assets/31bcb731-800f-4089-8bd2-841648bb7563" />


### Acceptance Criteria

- 📊 The UI should display the total amount of data pulled from the database in a human-readable format (e.g., KB, MB).
- ⏱️ The UI should show the total execution time and count of database queries.
- ⚠️ If a potential N+1 issue is detected, it should be highlighted in the query list.
- 🖱️ Clicking on a query should expand its details, including the full query and stack trace.
- ❌ The dialog should close when the user clicks outside it or on the close button.

## Implementation

- 🖼️ Updated the **frontend components** to include new fields for displaying data size, execution counts, and potential N+1 issues in the query dialog.
- 🛠️ Modified the **backend logic** in `PhoenixProfiler.Elements.EctoRepoUsage` to calculate and format the total data size pulled from the database.
- 🎨 Added new **CSS styles** in `priv/static/toolbar.css` to enhance the layout and design of the query dialog.
- 🖱️ Updated **JavaScript functionality** in `priv/static/toolbar.js` to handle dialog interactions, such as opening, closing, and toggling stack traces.
- 🗂️ Refactored the toolbar resource loading in `PhoenixProfiler.ToolbarLive` to use external resource paths for better maintainability.


