### PR TITLE
feat: sortable columns in query dialog (exec, time, data)

### DIFF
--- a/lib/phoenix_profiler/elements/ecto_repo_usage.ex
+++ b/lib/phoenix_profiler/elements/ecto_repo_usage.ex
@@ -52,9 +52,15 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
       <div class="phxprof-query-table-header">
         <span>Source</span>
         <span>Query</span>
-        <span>Exec.</span>
-        <span>Time</span>
-        <span>Data</span>
+        <button class="phxprof-sort-btn" data-sort-col="count">
+          Exec. <span class="phxprof-sort-icon">▼</span>
+        </button>
+        <button class="phxprof-sort-btn" data-sort-col="time">
+          Time <span class="phxprof-sort-icon"></span>
+        </button>
+        <button class="phxprof-sort-btn" data-sort-col="data">
+          Data <span class="phxprof-sort-icon"></span>
+        </button>
       </div>
       <div id="query_list" class="phxprof-query-list">
         <%= for query <- @queries do %>
@@ -65,11 +71,15 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
                 <span :if={query.possible_n_plus_one} class="phxprof-n-plus-one-badge">N+1</span>
                 {String.slice(query.query, 0..100)}
               </span>
-              <span class="phxprof-query-count">{query.execution_count}&times;</span>
-              <span class="phxprof-query-time">
+              <span class="phxprof-query-count" data-sort-value={query.execution_count}>
+                {query.execution_count}&times;
+              </span>
+              <span class="phxprof-query-time" data-sort-value={query.total_time_us}>
                 {query.total_time.value} {query.total_time.label}
               </span>
-              <span class="phxprof-query-data">{query.formatted_data_size}</span>
+              <span class="phxprof-query-data" data-sort-value={query.total_data_size}>
+                {query.formatted_data_size}
+              </span>
             </summary>
             <div class="phxprof-query-detail">
               <div>
@@ -178,6 +188,7 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
         )
 
       total_time = Enum.sum_by(filtered_entries, & &1.measurements.total_time)
+      total_time_us = System.convert_time_unit(total_time, :native, :microsecond)
 
       total_data_size = Enum.sum_by(filtered_entries, & &1.data_size)
 
@@ -185,6 +196,7 @@ defmodule PhoenixProfiler.Elements.EctoRepoUsage do
 
       Map.merge(unique_entry, %{
         total_time: formatted_duration(total_time),
+        total_time_us: total_time_us,
         execution_count: execution_count,
         total_data_size: total_data_size,
         formatted_data_size: format_bytes(total_data_size),

--- a/priv/static/toolbar.css
+++ b/priv/static/toolbar.css
@@ -269,6 +269,34 @@
   flex-shrink: 0;
 }
 
+.phxprof-sort-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-fg-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  width: 100%;
+}
+
+.phxprof-sort-btn:hover {
+  color: var(--color-fg-default);
+}
+
+.phxprof-sort-icon {
+  font-size: 0.6rem;
+  min-width: 0.6em;
+  display: inline-block;
+}
+
 .phxprof-query-list {
   overflow-y: auto;
   flex: 1;

--- a/priv/static/toolbar.js
+++ b/priv/static/toolbar.js
@@ -27,3 +27,52 @@ stacktraceDialog.addEventListener("click", (e) => {
 toggleToolbar(localStorage.getItem(SHOW) === "true");
 
 window.getPhxProfToken = () => toolbar.dataset.token;
+
+// ─── Query table sorting ────────────────────────────────────────────
+
+let querySort = { col: "count", dir: "desc" };
+
+function sortQueryList(col) {
+  const list = document.getElementById("query_list");
+  if (!list) return;
+
+  const rows = Array.from(list.querySelectorAll(".phxprof-query-row"));
+  if (rows.length === 0) return;
+
+  if (querySort.col === col) {
+    querySort.dir = querySort.dir === "asc" ? "desc" : "asc";
+  } else {
+    querySort.col = col;
+    querySort.dir = "desc";
+  }
+
+  const cellClass = {
+    count: ".phxprof-query-count",
+    time: ".phxprof-query-time",
+    data: ".phxprof-query-data",
+  }[col];
+
+  rows.sort((a, b) => {
+    const av = parseFloat(a.querySelector(cellClass)?.dataset.sortValue ?? 0);
+    const bv = parseFloat(b.querySelector(cellClass)?.dataset.sortValue ?? 0);
+    return querySort.dir === "asc" ? av - bv : bv - av;
+  });
+
+  rows.forEach((r) => list.appendChild(r));
+  updateSortHeaders();
+}
+
+function updateSortHeaders() {
+  document.querySelectorAll(".phxprof-sort-btn").forEach((btn) => {
+    const icon = btn.querySelector(".phxprof-sort-icon");
+    if (!icon) return;
+    icon.textContent = btn.dataset.sortCol === querySort.col
+      ? (querySort.dir === "asc" ? "▲" : "▼")
+      : "";
+  });
+}
+
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest(".phxprof-sort-btn");
+  if (btn) sortQueryList(btn.dataset.sortCol);
+});


### PR DESCRIPTION
## Summary

- Column headers **Exec.**, **Time**, and **Data** in the database query dialog are now clickable sort buttons
- Clicking a header sorts the query list by that column (desc by default); clicking again toggles asc/desc
- An ▲/▼ indicator shows the active sort column and direction

## Implementation details

- Raw numeric values are stored in `data-sort-value` attributes (`execution_count`, microseconds, raw bytes) so sorting is correct regardless of the displayed unit (KB/MB, ms/µs)
- Sorting is entirely client-side: JS reads the attributes, re-orders the `<details>` DOM nodes, and updates the header icons
- Event delegation on `document` (via `e.target.closest`) survives LiveView DOM patches without needing hooks or re-attachment
- Default sort on load is `execution_count desc`, matching the existing server-side sort order

## Test plan

- [ ] Open the query dialog on a page with multiple DB queries
- [ ] Click **Exec.** header → sorts by execution count desc (default); click again → asc
- [ ] Click **Time** header → sorts by total time desc; click again → asc
- [ ] Click **Data** header → sorts by data size desc; verify KB and MB rows sort in the correct numeric order (e.g. 1.2 MB > 900 KB)
- [ ] Confirm the active sort column shows ▲ or ▼, inactive columns show no icon
- [ ] Verify the toolbar still collapses/expands and the dialog still opens/closes normally